### PR TITLE
Rename `appsmith_systemd_required_systemd_services_list_*`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -186,10 +186,10 @@ appsmith_framing_prevention_enabled: true
 appsmith_hsts_preload_enabled: false
 
 # List of systemd services that the Appsmith systemd service depends on
-appsmith_systemd_required_services_list: "{{ appsmith_systemd_required_systemd_services_list_default + appsmith_systemd_required_systemd_services_list_auto + appsmith_systemd_required_systemd_services_list_custom }}"
-appsmith_systemd_required_systemd_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
-appsmith_systemd_required_systemd_services_list_auto: []
-appsmith_systemd_required_systemd_services_list_custom: []
+appsmith_systemd_required_services_list: "{{ appsmith_systemd_required_services_list_default + appsmith_systemd_required_services_list_auto + appsmith_systemd_required_services_list_custom }}"
+appsmith_systemd_required_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
+appsmith_systemd_required_services_list_auto: []
+appsmith_systemd_required_services_list_custom: []
 
 # List of systemd services that the Appsmith systemd service wants
 appsmith_systemd_wanted_services_list: []

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -4,6 +4,17 @@
 
 ---
 
+- name: (Deprecation) Catch and report renamed settings
+  ansible.builtin.fail:
+    msg: >-
+      Your configuration contains a variable, which now has a different name.
+      Please change your configuration to rename the variable (`{{ item.old }}` -> `{{ item.new }}`).
+  when: "item.old in vars"
+  with_items:
+    - {'old': 'appsmith_systemd_required_systemd_services_list_default', 'new': 'appsmith_systemd_required_services_list_default'}
+    - {'old': 'appsmith_systemd_required_systemd_services_list_auto', 'new': 'appsmith_systemd_required_services_list_auto'}
+    - {'old': 'appsmith_systemd_required_systemd_services_list_custom', 'new': 'appsmith_systemd_required_services_list_custom'}
+
 - name: Fail if required Appsmith settings not defined
   ansible.builtin.fail:
     msg: >


### PR DESCRIPTION
As this is not used on the template file of the MASH playbook, this change does not require instant release.