### PR TITLE
fix: add missing variable definition

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -224,6 +224,7 @@ appsmith_environment_variable_appsmith_client_log_level: error
 
 # Controls environment variables for email server
 appsmith_environment_variable_appsmith_mail_enabled: ''
+appsmith_environment_variable_appsmith_mail_host: ''
 appsmith_environment_variable_appsmith_mail_port: ''
 appsmith_environment_variable_appsmith_mail_username: ''
 appsmith_environment_variable_appsmith_mail_password: ''


### PR DESCRIPTION
The variable `appsmith_environment_variable_appsmith_mail_host` introduced in https://github.com/mother-of-all-self-hosting/ansible-role-appsmith/commit/759468a24d2e572322222a053c26586ac8beb25d is missing in `default/main.yml`, which cause an error.